### PR TITLE
Compatibility with PHP 8.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,77 @@
+name: CI
+
+on: [pull_request, workflow_dispatch]
+
+jobs:
+  phpstan:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version:
+          - 7.4
+          - 8.0
+          - 8.1
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          extensions: mbstring, sockets
+
+      - name: Get composer cache directory
+        id: composercache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composercache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer install --prefer-dist
+
+      - name: Run PHPStan
+        run: composer phpstan
+
+
+  phpcs:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version:
+          - 7.4
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          extensions: mbstring, sockets
+
+      - name: Get composer cache directory
+        id: composercache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composercache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer install --prefer-dist
+
+      - name: Run PHP CodeSniffer
+        run: composer phpcs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,6 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-          extensions: mbstring, sockets
 
       - name: Get composer cache directory
         id: composercache
@@ -57,7 +56,6 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-          extensions: mbstring, sockets
 
       - name: Get composer cache directory
         id: composercache

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
         "brandembassy/coding-standard": "^8.8"
     },
     "scripts": {
-        "phpcs": "vendor/bin/phpcs --standard=BrandEmbassyCodingStandard src",
-        "phpcbf": "./vendor/bin/phpcbf --standard=BrandEmbassyCodingStandard src",
+        "phpcs": "vendor/bin/phpcs --standard=BrandEmbassyCodingStandard src --runtime-set php_version 70400",
+        "phpcbf": "./vendor/bin/phpcbf --standard=BrandEmbassyCodingStandard src --runtime-set php_version 70400",
         "phpstan": "./vendor/bin/phpstan analyse -c phpstan.neon src"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "php": ">=7.4"
     },
     "require-dev": {
-        "brandembassy/coding-standard": "^5.0"
+        "brandembassy/coding-standard": "^8.8"
     },
     "scripts": {
         "phpcs": "vendor/bin/phpcs --standard=BrandEmbassyCodingStandard src",

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     },
     "config": {
         "sort-packages": true,
+        "lock": false,
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
         }

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         }
     },
     "require": {
-        "php": "~7.4"
+        "php": ">=7.4"
     },
     "require-dev": {
         "brandembassy/coding-standard": "^5.0"

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
         "phpstan": "./vendor/bin/phpstan analyse -c phpstan.neon src"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }

--- a/src/CurrentDateTimeImmutableFactory.php
+++ b/src/CurrentDateTimeImmutableFactory.php
@@ -4,7 +4,10 @@ namespace BrandEmbassy\DateTime;
 
 use DateTimeImmutable;
 
-final class CurrentDateTimeImmutableFactory implements DateTimeImmutableFactory
+/**
+ * @final
+ */
+class CurrentDateTimeImmutableFactory implements DateTimeImmutableFactory
 {
     public function getNow(): DateTimeImmutable
     {

--- a/src/FrozenDateTimeImmutableFactory.php
+++ b/src/FrozenDateTimeImmutableFactory.php
@@ -4,12 +4,12 @@ namespace BrandEmbassy\DateTime;
 
 use DateTimeImmutable;
 
-final class FrozenDateTimeImmutableFactory implements DateTimeImmutableFactory
+/**
+ * @final
+ */
+class FrozenDateTimeImmutableFactory implements DateTimeImmutableFactory
 {
-    /**
-     * @var DateTimeImmutable
-     */
-    private $frozenAt;
+    private DateTimeImmutable $frozenAt;
 
 
     public function __construct(DateTimeImmutable $frozenAt)


### PR DESCRIPTION
This PR allows for PHP 8.0, also bumps coding standard version (required for PHP 8.0) and adds GitHub Actions workflow.

I suggest releasing this as a MINOR version (1.2.0).